### PR TITLE
Avoid blocking due to FFProbe warnings

### DIFF
--- a/ffprobe/ffprobe.py
+++ b/ffprobe/ffprobe.py
@@ -31,9 +31,9 @@ class FFProbe:
 
         if os.path.isfile(self.path_to_video):
             if platform.system() == 'Windows':
-                cmd = ["ffprobe", "-show_streams", self.path_to_video]
+                cmd = ["ffprobe", "-show_streams", "-v", "quiet", self.path_to_video]
             else:
-                cmd = ["ffprobe -show_streams " + pipes.quote(self.path_to_video)]
+                cmd = ["ffprobe -show_streams -v quiet " + pipes.quote(self.path_to_video)]
 
             p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='ffprobe-python',
-    version='1.0.3+metricasports.1',
+    version='1.0.3+metricasports.2',
     description="""
     A wrapper around ffprobe command to extract metadata from media files.
     """,


### PR DESCRIPTION
Set verbose mode to quiet to avoid blocking process `stdout` when reading streams info. This happens on videos that have some errors and/or warnings.